### PR TITLE
Fix working directory issue by using script base path instead of os.g…

### DIFF
--- a/freenet.pyw
+++ b/freenet.pyw
@@ -59,6 +59,10 @@ class VPNConfigGUI:
         self.root = root
         self.root.title("VPN Config Manager")
         self.root.geometry("600x600+620+20")
+
+        # Define BASE_DIR at the beginning of __init__
+        self.BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
         
         # Configure dark theme
         self.setup_dark_theme()
@@ -95,11 +99,11 @@ class VPNConfigGUI:
         
         
         
-        self.TEMP_FOLDER = os.path.join(os.getcwd(), "temp")
+        self.TEMP_FOLDER = os.path.join(self.BASE_DIR, "temp")
         self.TEMP_CONFIG_FILE = os.path.join(self.TEMP_FOLDER, "temp_config.json")
         
         
-        self.XRAY_PATH = os.path.join(os.getcwd(), "xray.exe" if sys.platform == 'win32' else "xray")
+        self.XRAY_PATH = os.path.join(self.BASE_DIR, "xray.exe" if sys.platform == 'win32' else "xray")
         
         
         


### PR DESCRIPTION
…etcwd()

Previously, the program used `os.getcwd()` to define paths for temporary files and the Xray executable. This caused issues when the script was launched from a different working directory, as it couldn't locate the necessary files (e.g., Xray and config files located in the "temp" folder).

This PR replaces `os.getcwd()` with the absolute path of the script file using:

    self.BASE_DIR = os.path.dirname(os.path.abspath(__file__))

and updates all relevant paths to be based on `self.BASE_DIR`. This ensures the program works reliably regardless of where it is executed from.

Tested on Fedora Workstation — Xray now runs correctly from any working directory.